### PR TITLE
Add realtime EQ and visualizer to GUI player

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,15 @@ python chord_melody_cli.py <audio-file>
 The tool prints the detected key, chord progression, and a simple melody line
 with timestamps.
 
+## GUI player
+
+`chord_player_v43.py` now includes a realtime audio player with a 5‑band
+equaliser and waveform/spectrum visualiser. Optional dependencies:
+
+```
+pip install sounddevice pyqtgraph
+```
+
+If realtime audio is unavailable the player falls back to the previous
+`pygame` based playback.
+


### PR DESCRIPTION
## Summary
- add five-band peaking EQ and realtime sounddevice playback
- include pyqtgraph waveform and spectrum visualizer with EQ controls
- update volume/playback logic to use realtime player when available

## Testing
- `python -m py_compile chord_player_v43.py`


------
https://chatgpt.com/codex/tasks/task_e_689da4fad1b8832aa6df1d0135780d3b