### PR TITLE
Add stem separation via HPSS and Demucs

### DIFF
--- a/chord_melody_cli.py
+++ b/chord_melody_cli.py
@@ -1,30 +1,56 @@
 #!/usr/bin/env python3
-"""Command line utility for chord and melody detection.
-
-Usage::
-
-    python chord_melody_cli.py <audio-file>
-
-The script prints detected chord progression and a simple melody line with
-timestamps. It relies on the analysis routines implemented in
-``chord_player_v43``.
-"""
+"""Command line utility for chord and melody detection with optional stem separation."""
 
 from __future__ import annotations
 
-import sys
+import argparse
+import json
+import os
+import tempfile
 
-from chord_player_v43 import detect_chords
+import numpy as np
+import librosa
+import soundfile as sf
+
+from chord_player_v43 import detect_chords, StemSeparator
 
 
 def main() -> None:
-    if len(sys.argv) < 2:
-        print("Usage: python chord_melody_cli.py <audio-file>")
-        sys.exit(1)
+    p = argparse.ArgumentParser(description="Chord and melody detection")
+    p.add_argument("audio", help="Input audio file")
+    p.add_argument("--json", type=str, help="Write results to JSON file")
+    p.add_argument("--stems", choices=["hpss", "two", "four"], help="Separate stems")
+    p.add_argument("--stems-out", type=str, help="Directory to write stem WAVs")
+    args = p.parse_args()
 
-    path = sys.argv[1]
+    y, sr = librosa.load(args.audio, sr=None, mono=False)
+    y_for_analysis = librosa.to_mono(y)
+    stems = {}
 
-    chords, key_sig, stats = detect_chords(path)
+    if args.stems:
+        sep = StemSeparator(fs=sr)
+        if args.stems == "hpss":
+            stems, srr = sep.hpss(y, sr)
+            stems = {k: (np.stack([v, v], axis=0) if v.ndim == 1 else v) for k, v in stems.items()}
+        else:
+            mode = "two_stems" if args.stems == "two" else "four_stems"
+            stems, srr, _ = sep.demucs(y, sr, mode=mode)
+        if args.stems_out:
+            os.makedirs(args.stems_out, exist_ok=True)
+            for name, buf in stems.items():
+                sf.write(os.path.join(args.stems_out, f"{name}.wav"), buf.T, srr)
+        if "instrumental" in stems:
+            y_for_analysis = librosa.to_mono(stems["instrumental"])
+            sr = srr
+
+    if args.stems and "instrumental" in stems:
+        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        sf.write(tmp.name, y_for_analysis, sr)
+        tmp.close()
+        chords, key_sig, stats = detect_chords(tmp.name)
+        os.unlink(tmp.name)
+    else:
+        chords, key_sig, stats = detect_chords(args.audio)
 
     print(f"Detected key: {key_sig}")
     print("\nChords:")
@@ -38,6 +64,10 @@ def main() -> None:
             print(f"{t:6.2f}s: {note}")
     else:
         print("  (no melody detected)")
+
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as f:
+            json.dump({"key": key_sig, "chords": chords, "stats": stats}, f, indent=2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `StemSeparator` with fast HPSS and Demucs engines
- integrate `StemsPanel` GUI to mix separated stems and improve analysis
- extend CLI with optional stem separation, export, and JSON output

## Testing
- `python -m py_compile chord_player_v43.py chord_melody_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_689da73114b0832a9ad01c015410a459